### PR TITLE
Added group info to scene scraper

### DIFF
--- a/scrapers/Ersties/Ersties.py
+++ b/scrapers/Ersties/Ersties.py
@@ -76,6 +76,7 @@ def get_scene(inputurl):
         ret['code'] = str(scrape_data['id'])
         ret['details'] = clean_text(str(scrape_data['gallery']['description_en'])) 
         ret['studio'] = {'name':'Ersties'}
+        ret['groups'] = [{'name': scrape_data['gallery']['title_en']}]
         ret['tags'] = [{'name': x['name_en']} for x in scrape_data['tags']]
         ret['performers'] = [{'name': x['name_en']} for x in scrape_data['participated_models']]
         for thumbnail in scrape_data['thumbnails']:


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] movieByURL
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

https://ersties.com/shoot/6677#play-8235-comments

## Short description

Added Group/Shoot info to the scene scraper
